### PR TITLE
Improve :GoshitekiStart error message

### DIFF
--- a/autoload/goshiteki.vim
+++ b/autoload/goshiteki.vim
@@ -19,10 +19,7 @@ function! g:goshiteki#start_review() abort
 
   let l:pr = split(system([s:script_dir . 'pr-id.sh', trim(l:owner), trim(l:name), trim(l:current_branch)]), "\n")
 
-  if len(l:pr) == 0
-    echoerr 'A pull request is not found.'
-    return
-  elseif len(l:pr) == 1
+  if v:shell_error != 0
     echoerr l:pr[0]
     return
   endif

--- a/autoload/goshiteki.vim
+++ b/autoload/goshiteki.vim
@@ -18,6 +18,15 @@ function! g:goshiteki#start_review() abort
   let l:name = l:owner_and_name[-1]
 
   let l:pr = split(system([s:script_dir . 'pr-id.sh', trim(l:owner), trim(l:name), trim(l:current_branch)]), "\n")
+
+  if len(l:pr) == 0
+    echoerr 'A pull request is not found.'
+    return
+  elseif len(l:pr) == 1
+    echoerr l:pr[0]
+    return
+  endif
+
   let [s:pr_id, s:base_branch] = l:pr
   echo s:base_branch
 endfunction

--- a/commands/pr-id.sh
+++ b/commands/pr-id.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 pr-id() {
-  gh api graphql \
+  local result
+
+  result=$(gh api graphql \
     -F owner="$1" \
     -F name="$2" \
     -F headRefName="$3" \
@@ -18,7 +20,14 @@ pr-id() {
         }
       }
     }
-  ' | jq -r '.data | select(.repository != null) | .repository.pullRequests.edges | select(.[] != null)[0].node[]'
+  ')
+
+  (( $? )) && return 1
+
+  if ! jq -r '.data.repository.pullRequests.edges[0].node[]' <<< $result 2> /dev/null; then
+    echo 'The pull request was not found.'
+    return 2
+  fi
 }
 
 

--- a/commands/pr-id.sh
+++ b/commands/pr-id.sh
@@ -18,7 +18,7 @@ pr-id() {
         }
       }
     }
-  ' | jq -r '.data.repository.pullRequests.edges[0].node[]' 
+  ' | jq -r '.data | select(.repository != null) | .repository.pullRequests.edges | select(.[] != null)[0].node[]'
 }
 
 

--- a/commands/pr-id.sh
+++ b/commands/pr-id.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 pr-id() {
+  set -o pipefail
   local result
 
-  result=$(gh api graphql \
+  result="$(gh api graphql \
     -F owner="$1" \
     -F name="$2" \
     -F headRefName="$3" \
@@ -20,14 +21,16 @@ pr-id() {
         }
       }
     }
-  ')
+  ' | jq -r '(.data.repository.pullRequests.edges[0].node // {})[]')"
 
-  (( $? )) && return 1
+  (( "$?" )) && return 1
 
-  if ! jq -r '.data.repository.pullRequests.edges[0].node[]' <<< $result 2> /dev/null; then
+  if [[ -z "$result" ]]; then
     echo 'The pull request was not found.'
     return 2
   fi
+
+  echo "$result"
 }
 
 


### PR DESCRIPTION
`オーナー名`、`リポジトリー名`、`ブランチに対応するPR`がない場合、nullによってjqのパースが失敗していたのでjqのエラーメッセージが出ないようにしました。また、`:GoshitekiStart`を実行したときに表示されるメッセージを具体的にしました。