### PR TITLE
Use merge-base to against which commit to compare

### DIFF
--- a/commands/review-comments.sh
+++ b/commands/review-comments.sh
@@ -10,11 +10,11 @@ review-comments() {
   local body=$4
   local base_branch=$5
 
-  if ! git diff --diff-algorithm=default "$base_branch" -- "$path" | "$(dirname -- "$0")"/line-in-range.sh "$start_line" add; then
+  if ! git diff --diff-algorithm=default "$(git merge-base HEAD "$base_branch")" -- "$path" | "$(dirname -- "$0")"/line-in-range.sh "$start_line" add; then
     return 1
   fi
 
-  if ! git diff --diff-algorithm=default "$base_branch" -- "$path" | "$(dirname -- "$0")"/line-in-range.sh "$end_line" add; then
+  if ! git diff --diff-algorithm=default "$(git merge-base HEAD "$base_branch")" -- "$path" | "$(dirname -- "$0")"/line-in-range.sh "$end_line" add; then
     return 1
   fi
 


### PR DESCRIPTION
`merge-base` を使わないと PR の対象と直接比較してしまい不要な差分が含まれるので修正した。