### PR TITLE
Move .REVIEW_COMMENT_STATE to .git

### DIFF
--- a/autoload/goshiteki.vim
+++ b/autoload/goshiteki.vim
@@ -28,6 +28,11 @@ endfunction
 function! g:goshiteki#add_review_comment() range abort
   let s:add_review_comment_tempname = tempname()
   let s:git_root = trim(system(['git', 'rev-parse', '--show-toplevel'])) . '/'
+  let s:git_dir = getenv('GIT_DIR')
+  if s:git_dir == 0
+    let s:git_dir = '.git'
+  endif
+
   let s:absolute_current_file_path = expand('%:p')
   let s:relative_file_path_from_git_root = split(s:absolute_current_file_path, s:git_root)[0]
 
@@ -62,7 +67,7 @@ endfunction
 
 function! g:goshiteki#post_submit(status, tempname, pr_id) abort
   let l:body = join(readfile(a:tempname), "\n")
-  call system([s:script_dir . 'submit-review.sh', a:pr_id, l:body, a:status, './.REVIEW_COMMENT_STATE'])
+  call system([s:script_dir . 'submit-review.sh', a:pr_id, l:body, a:status, s:git_root . s:git_dir . '/REVIEW_COMMENT_STATE'])
   echo 'Submit review(status: ' . 'a:status' . ')'
 endfunction
 

--- a/autoload/goshiteki.vim
+++ b/autoload/goshiteki.vim
@@ -1,26 +1,21 @@
 let g:loaded_goshiteki = 1
 let s:script_dir = expand('<sfile>:p:h') . '/../commands/'
-let s:pr_id = ""
-let s:base_branch = ""
+let s:pr_id = ''
+let s:base_branch = ''
 let s:start_position = 0
 let s:end_position = 0
 
 function! g:goshiteki#start_review() abort
-  let l:current_branch = system("git symbolic-ref --short HEAD")
-  let l:origin_url = trim(system("git remote get-url origin"))
-  let l:owner_and_name = ""
+  let l:current_branch = trim(system('git symbolic-ref --short HEAD'))
+  let l:origin_url = trim(system('git remote get-url origin'))
 
-  if match(l:origin_url, "^git[@:]") !=# -1
-    let l:owner_and_name = split(matchstr(trim(system("git remote get-url origin")), ":.*/.*\.git$")[1:-5], '/')
+  if match(l:origin_url, '^git[@:]') !=# -1
+    let [l:owner, l:name] = split(matchstr(trim(system('git remote get-url origin')), ':.*/.*\.git$')[1:-5], '/')
   else
-    let l:owner_and_name = split(matchstr(trim(system("git remote get-url origin")), "/.*/.*$")[1:], '/')
+    let [l:owner, l:name] = split(matchstr(trim(system('git remote get-url origin')), '/.*/.*$')[1:], '/')
   endif
 
-  let l:owner = l:owner_and_name[-2]
-  let l:name = l:owner_and_name[-1]
-
-  let l:pr = split(system([s:script_dir . 'pr-id.sh', trim(l:owner), trim(l:name), trim(l:current_branch)]), "\n")
-
+  let l:pr = systemlist([s:script_dir . 'pr-id.sh', l:owner, l:name, l:current_branch])
   if v:shell_error != 0
     echoerr l:pr[0]
     return
@@ -38,7 +33,7 @@ function! g:goshiteki#add_review_comment() range abort
 
   let s:start_position = a:firstline
   let s:end_position = a:lastline
-  let s:start_position = line(".")
+  let s:start_position = line('.')
 
   execute 'split ' . s:add_review_comment_tempname
   set filetype=markdown
@@ -49,7 +44,6 @@ endfunction
 function! g:goshiteki#post_write_review_comment(relative_path_from_git_root, start_position, end_position, comment_file_name, output_json) abort
   let l:comment = join(readfile(a:comment_file_name), "\n")
   let result = system([s:script_dir . 'review-comments.sh', a:relative_path_from_git_root, a:start_position, a:end_position, l:comment, a:output_json, s:base_branch])
-
   echo result
 
   " Clean up position variables
@@ -68,8 +62,8 @@ endfunction
 
 function! g:goshiteki#post_submit(status, tempname, pr_id) abort
   let l:body = join(readfile(a:tempname), "\n")
-  call system([s:script_dir . 'submit-review.sh', a:pr_id, l:body, a:status, "./.REVIEW_COMMENT_STATE"])
-  echo "Submit review(status: " . "a:status" . ")"
+  call system([s:script_dir . 'submit-review.sh', a:pr_id, l:body, a:status, './.REVIEW_COMMENT_STATE'])
+  echo 'Submit review(status: ' . 'a:status' . ')'
 endfunction
 
 function! g:goshiteki#target() abort

--- a/autoload/goshiteki.vim
+++ b/autoload/goshiteki.vim
@@ -71,7 +71,7 @@ function! g:goshiteki#post_submit(status, tempname, pr_id) abort
     let l:body = join(readfile(a:tempname), "\n")
   endif
   call system([s:script_dir . 'submit-review.sh', a:pr_id, l:body, a:status, s:git_root . s:git_dir . '/REVIEW_COMMENT_STATE'])
-  echo 'Submit review(status: ' . 'a:status' . ')'
+  echo 'Submit review(status: ' . a:status . ')'
 endfunction
 
 function! g:goshiteki#target() abort

--- a/commands/review-comments.sh
+++ b/commands/review-comments.sh
@@ -2,7 +2,7 @@
 
 # review-comments readme.md 1 body json
 review-comments() {
-  local REVIEW_COMMENT_STATE="./.REVIEW_COMMENT_STATE"
+  local REVIEW_COMMENT_STATE=$(git rev-parse --show-toplevel)/${GIT_DIR:-.git}/REVIEW_COMMENT_STATE
   local current=$(cat -- "$REVIEW_COMMENT_STATE" 2> /dev/null)
   local path=$1
   local start_line=$2


### PR DESCRIPTION
* `REVIEW_COMMENT_STATE` を `.git` 以下に移動（fix #23）
* `\n` を使っている箇所以外はシングルクォートに統一
* 分割代入と `systemlist` への置き換えで読みやすく